### PR TITLE
Conditionally require pytest-runner

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,9 @@
+import sys
 from setuptools import setup
+
+setup_requires = []
+if set(['pytest', 'test', 'ptr']).intersection(sys.argv):
+    setup_requires.append('pytest-runner')
 
 classifiers = [
     "License :: OSI Approved :: MIT License",
@@ -16,7 +21,7 @@ setup(
     author='deginner',
     author_email='support@deginner.com',
     description='A centralized ledger suitable for use like a cryptocurrency hot wallet.',
-    setup_requires=['pytest-runner'],
+    setup_requires=setup_requires,
     package_data={'desw': ['static/swagger.json']},
     install_requires=[
         'sqlalchemy>=1.0.9',


### PR DESCRIPTION
pytest-runner is not needed for deployment; avoid it as a build-time
dependency unless actually used. (It in turn has a setup_requires of
setuptools-scm, so we avoid going further down the rabbit hole.)

This may be ugly, but is officially suggested:
http://pythonhosted.org/pytest-runner/#conditional-requirement

[Similar on the way for other repos if approved.]
